### PR TITLE
feat: Web Content Extraction from URL

### DIFF
--- a/.github/ISSUE_DRAFTS/01-web-content-extraction.md
+++ b/.github/ISSUE_DRAFTS/01-web-content-extraction.md
@@ -1,0 +1,22 @@
+## Description
+Allow users to paste a URL and automatically extract the main text content from the webpage for TTS playback.
+
+## User Story
+As a user, I want to paste a URL so that I can listen to web articles without manually copying the text.
+
+## Acceptance Criteria
+- [ ] User can paste a URL in the input field
+- [ ] App detects if input is a URL (regex validation)
+- [ ] App fetches and parses the webpage content
+- [ ] Main article content is extracted (remove ads, navigation, etc.)
+- [ ] Extracted text is displayed and ready for TTS playback
+- [ ] Loading indicator shown during fetch
+- [ ] Error handling for invalid URLs or failed requests
+
+## Technical Notes
+- Consider using packages like `html` for parsing
+- Implement a backend proxy or use a service like Mercury/Readability API for better extraction
+- Handle rate limiting and timeouts gracefully
+
+## Priority
+P0 - Core feature from original vision

--- a/.github/ISSUE_DRAFTS/02-reading-history.md
+++ b/.github/ISSUE_DRAFTS/02-reading-history.md
@@ -1,0 +1,27 @@
+## Description
+Save previously read texts locally so users can revisit and replay them later.
+
+## User Story
+As a user, I want to see my reading history so that I can easily replay articles I have listened to before.
+
+## Acceptance Criteria
+- [ ] Each text/URL is saved after playback starts
+- [ ] History screen displays list of previous readings
+- [ ] Each history item shows: title/preview, date, source (text/URL)
+- [ ] User can tap to replay any history item
+- [ ] User can delete individual items or clear all history
+- [ ] History persists across app restarts
+- [ ] Maximum history limit (e.g., 100 items) with auto-cleanup
+
+## Technical Notes
+- Use hive, isar, or sqflite for local storage
+- Store metadata: id, title, content, sourceUrl, createdAt, lastPlayedAt
+- Consider lazy loading for large history lists
+
+## UI/UX
+- Add history icon in app bar or bottom navigation
+- Swipe-to-delete gesture for history items
+- Empty state with helpful message
+
+## Priority
+P0 - Essential for user retention

--- a/.github/ISSUE_DRAFTS/03-background-playback.md
+++ b/.github/ISSUE_DRAFTS/03-background-playback.md
@@ -1,0 +1,21 @@
+## Description
+Enable audio playback to continue when the app is in the background or the screen is locked.
+
+## User Story
+As a user, I want to lock my phone and continue listening so that I can save battery and avoid accidental touches.
+
+## Acceptance Criteria
+- [ ] Audio continues playing when app goes to background
+- [ ] Audio continues when screen is locked
+- [ ] Works with both ElevenLabs (cloud) and local TTS
+- [ ] Proper audio session configuration for iOS and Android
+- [ ] App resumes correctly when brought back to foreground
+
+## Technical Notes
+- audio_session package is already included
+- Verify iOS AVAudioSessionCategory.playback is properly configured
+- Android: may need foreground service for reliable background playback
+- Test with Bluetooth headphones and car audio
+
+## Priority
+P0 - Critical for user experience

--- a/.github/ISSUE_DRAFTS/04-media-notification-controls.md
+++ b/.github/ISSUE_DRAFTS/04-media-notification-controls.md
@@ -1,0 +1,22 @@
+## Description
+Display playback controls in the system notification/control center for easy access without opening the app.
+
+## User Story
+As a user, I want to control playback from my lock screen or notification shade so that I do not have to unlock and open the app.
+
+## Acceptance Criteria
+- [ ] Notification shows current reading title/preview
+- [ ] Play/Pause button in notification
+- [ ] Stop button in notification
+- [ ] Notification updates when playback state changes
+- [ ] Works on both iOS (Control Center) and Android (notification)
+- [ ] Notification dismissed when playback stops
+
+## Technical Notes
+- Use audio_service or just_audio_background package
+- Integrate with existing TtsController
+- Handle notification actions to control TtsController
+- Consider adding skip forward/backward (30 seconds)
+
+## Priority
+P1 - Important for background playback experience

--- a/.github/ISSUE_DRAFTS/05-audio-export-mp3.md
+++ b/.github/ISSUE_DRAFTS/05-audio-export-mp3.md
@@ -1,0 +1,22 @@
+## Description
+Allow users to download and save the generated audio as an MP3 file to their device.
+
+## User Story
+As a user, I want to save audio files so that I can listen offline without regenerating the audio.
+
+## Acceptance Criteria
+- [ ] Download button available after audio generation
+- [ ] Audio saved to device storage (Downloads folder)
+- [ ] User notified when download completes
+- [ ] Support for ElevenLabs generated audio (already MP3)
+- [ ] Option to convert local TTS to audio file
+- [ ] Filename based on content title or first words
+
+## Technical Notes
+- ElevenLabs already generates MP3 files (stored in temp)
+- Move from temp to permanent storage instead of deleting
+- For local TTS, use flutter_tts synthesizeToFile method
+- Use path_provider and permission_handler for file access
+
+## Priority
+P1 - High value feature for offline use

--- a/.github/ISSUE_DRAFTS/06-reading-progress-indicator.md
+++ b/.github/ISSUE_DRAFTS/06-reading-progress-indicator.md
@@ -1,0 +1,21 @@
+## Description
+Show a visual progress bar and highlight the currently spoken text during playback.
+
+## User Story
+As a user, I want to see my reading progress so that I know how much content remains and can follow along visually.
+
+## Acceptance Criteria
+- [ ] Progress bar shows current position in audio
+- [ ] Progress bar is seekable (tap to jump to position)
+- [ ] Current word or sentence is highlighted in text view
+- [ ] Time elapsed and time remaining displayed
+- [ ] Progress syncs with actual TTS position
+
+## Technical Notes
+- Local TTS: Use onProgress callback (provides word boundaries)
+- ElevenLabs: Track audio player position vs total duration
+- May need to implement word-level timing for text highlighting
+- Consider sentence-level highlighting as simpler alternative
+
+## Priority
+P1 - Enhances reading experience significantly

--- a/lib/core/services/web_extractor_service.dart
+++ b/lib/core/services/web_extractor_service.dart
@@ -1,0 +1,594 @@
+import 'dart:math';
+
+import 'package:html/parser.dart' as html_parser;
+import 'package:html/dom.dart';
+import 'package:http/http.dart' as http;
+
+/// Result of web content extraction
+class ExtractedContent {
+  final String title;
+  final String content;
+  final String? description;
+  final String? imageUrl;
+  final String sourceUrl;
+
+  const ExtractedContent({
+    required this.title,
+    required this.content,
+    this.description,
+    this.imageUrl,
+    required this.sourceUrl,
+  });
+
+  bool get isEmpty => content.trim().isEmpty;
+  bool get isNotEmpty => !isEmpty;
+}
+
+/// Service for extracting readable content from web pages
+/// Implements a Readability-like algorithm for content extraction
+class WebExtractorService {
+  static const _timeout = Duration(seconds: 15);
+
+  // Elements that are unlikely to contain main content
+  static const _unlikelyCandidates = [
+    'banner',
+    'breadcrumbs',
+    'combx',
+    'comment',
+    'community',
+    'cover-wrap',
+    'disqus',
+    'extra',
+    'footer',
+    'gdpr',
+    'header',
+    'legends',
+    'menu',
+    'related',
+    'remark',
+    'replies',
+    'rss',
+    'shoutbox',
+    'sidebar',
+    'skyscraper',
+    'social',
+    'sponsor',
+    'supplemental',
+    'ad-break',
+    'agegate',
+    'pagination',
+    'pager',
+    'popup',
+    'yom-hierarchical-nav',
+    'yom-remote',
+  ];
+
+  // Elements that might be content candidates
+  static const _okMaybeItsACandidate = [
+    'and',
+    'article',
+    'body',
+    'column',
+    'content',
+    'main',
+    'shadow',
+  ];
+
+  // Positive indicators for content
+  static const _positivePatterns = [
+    'article',
+    'body',
+    'content',
+    'entry',
+    'hentry',
+    'h-entry',
+    'main',
+    'page',
+    'pagination',
+    'post',
+    'text',
+    'blog',
+    'story',
+  ];
+
+  // Negative indicators
+  static const _negativePatterns = [
+    'hidden',
+    'banner',
+    'combx',
+    'comment',
+    'com-',
+    'contact',
+    'foot',
+    'footer',
+    'footnote',
+    'gdpr',
+    'masthead',
+    'media',
+    'meta',
+    'outbrain',
+    'promo',
+    'related',
+    'scroll',
+    'share',
+    'shoutbox',
+    'sidebar',
+    'skyscraper',
+    'sponsor',
+    'shopping',
+    'tags',
+    'tool',
+    'widget',
+  ];
+
+  // Elements to completely remove
+  static const _removeElements = [
+    'script',
+    'style',
+    'nav',
+    'footer',
+    'header',
+    'aside',
+    'form',
+    'iframe',
+    'noscript',
+    'svg',
+    'canvas',
+    'button',
+    'input',
+    'select',
+    'textarea',
+    'figure.wp-block-embed',
+  ];
+
+  /// Check if a string is a valid URL
+  static bool isValidUrl(String text) {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return false;
+
+    // Simple URL pattern check
+    final urlPattern = RegExp(
+      r'^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?(\?[^\s]*)?$',
+      caseSensitive: false,
+    );
+
+    return urlPattern.hasMatch(trimmed) ||
+        trimmed.startsWith('http://') ||
+        trimmed.startsWith('https://');
+  }
+
+  /// Normalize URL (add https if missing)
+  static String normalizeUrl(String url) {
+    final trimmed = url.trim();
+    if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
+      return 'https://$trimmed';
+    }
+    return trimmed;
+  }
+
+  /// Extract content from a URL using Readability-like algorithm
+  Future<ExtractedContent> extractFromUrl(String url) async {
+    final normalizedUrl = normalizeUrl(url);
+
+    try {
+      // Fetch the page
+      final response = await http.get(
+        Uri.parse(normalizedUrl),
+        headers: {
+          'User-Agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+          'Accept':
+              'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.9,fr;q=0.8',
+          'Cache-Control': 'no-cache',
+        },
+      ).timeout(_timeout);
+
+      if (response.statusCode != 200) {
+        throw WebExtractorException(
+          'Failed to fetch page: HTTP ${response.statusCode}',
+          code: WebExtractorErrorCode.httpError,
+        );
+      }
+
+      // Parse HTML
+      final document = html_parser.parse(response.body);
+
+      // Extract metadata
+      final title = _extractTitle(document);
+      final description = _extractDescription(document);
+      final imageUrl = _extractImage(document, normalizedUrl);
+
+      // Apply Readability algorithm
+      final content = _extractWithReadability(document);
+
+      if (content.trim().isEmpty) {
+        throw WebExtractorException(
+          'Could not extract content from page',
+          code: WebExtractorErrorCode.noContent,
+        );
+      }
+
+      return ExtractedContent(
+        title: title,
+        content: content,
+        description: description,
+        imageUrl: imageUrl,
+        sourceUrl: normalizedUrl,
+      );
+    } on WebExtractorException {
+      rethrow;
+    } catch (e) {
+      if (e.toString().contains('SocketException') ||
+          e.toString().contains('HandshakeException')) {
+        throw WebExtractorException(
+          'Network error: Could not connect to server',
+          code: WebExtractorErrorCode.networkError,
+        );
+      }
+      if (e.toString().contains('TimeoutException')) {
+        throw WebExtractorException(
+          'Request timed out',
+          code: WebExtractorErrorCode.timeout,
+        );
+      }
+      throw WebExtractorException(
+        'Failed to extract content: $e',
+        code: WebExtractorErrorCode.unknown,
+      );
+    }
+  }
+
+  /// Main Readability-like extraction algorithm
+  String _extractWithReadability(Document document) {
+    // Step 1: Remove unwanted elements
+    _removeUnwantedElements(document);
+
+    // Step 2: Try to find article element first (most reliable)
+    final article = document.querySelector('article');
+    if (article != null) {
+      final text = _extractTextFromElement(article);
+      if (text.length > 200) {
+        return text;
+      }
+    }
+
+    // Step 3: Score all candidate elements
+    final candidates = <Element, double>{};
+    final body = document.body;
+    if (body == null) return '';
+
+    // Find all paragraphs and score their parents
+    final paragraphs = body.querySelectorAll('p');
+    for (final p in paragraphs) {
+      final text = p.text.trim();
+      if (text.length < 25) continue;
+
+      // Get parent and grandparent
+      final parent = p.parent;
+      final grandparent = parent?.parent;
+
+      if (parent == null) continue;
+
+      // Initialize scores
+      candidates.putIfAbsent(parent, () => _getInitialScore(parent));
+      if (grandparent != null) {
+        candidates.putIfAbsent(grandparent, () => _getInitialScore(grandparent));
+      }
+
+      // Calculate content score
+      var contentScore = 1.0;
+      contentScore += text.split(',').length; // Comma bonus
+      contentScore += min((text.length / 100).floor(), 3).toDouble(); // Length bonus
+
+      // Add to parent score
+      candidates[parent] = candidates[parent]! + contentScore;
+
+      // Add half to grandparent
+      if (grandparent != null) {
+        candidates[grandparent] = candidates[grandparent]! + (contentScore / 2);
+      }
+    }
+
+    // Step 4: Find the best candidate
+    Element? bestCandidate;
+    double bestScore = 0;
+
+    candidates.forEach((element, score) {
+      // Apply link density penalty
+      final linkDensity = _getLinkDensity(element);
+      final adjustedScore = score * (1 - linkDensity);
+
+      if (adjustedScore > bestScore) {
+        bestScore = adjustedScore;
+        bestCandidate = element;
+      }
+    });
+
+    // Step 5: Extract text from best candidate
+    if (bestCandidate != null) {
+      return _extractTextFromElement(bestCandidate!);
+    }
+
+    // Fallback: try main or content div
+    final main = document.querySelector('main, [role="main"], #content, .content');
+    if (main != null) {
+      return _extractTextFromElement(main);
+    }
+
+    // Last resort: get all paragraphs from body
+    return _extractTextFromElement(body);
+  }
+
+  /// Get initial score for an element based on tag and class/id
+  double _getInitialScore(Element element) {
+    var score = 0.0;
+    final tagName = element.localName?.toLowerCase() ?? '';
+
+    // Score by tag
+    switch (tagName) {
+      case 'article':
+        score += 25;
+        break;
+      case 'section':
+        score += 15;
+        break;
+      case 'div':
+        score += 5;
+        break;
+      case 'pre':
+      case 'td':
+      case 'blockquote':
+        score += 3;
+        break;
+      case 'form':
+      case 'ul':
+      case 'ol':
+      case 'dl':
+        score -= 3;
+        break;
+      case 'nav':
+      case 'header':
+      case 'footer':
+      case 'aside':
+        score -= 25;
+        break;
+    }
+
+    // Score by class and id
+    final classId = '${element.className} ${element.id}'.toLowerCase();
+
+    for (final pattern in _positivePatterns) {
+      if (classId.contains(pattern)) {
+        score += 25;
+        break;
+      }
+    }
+
+    for (final pattern in _negativePatterns) {
+      if (classId.contains(pattern)) {
+        score -= 25;
+        break;
+      }
+    }
+
+    return score;
+  }
+
+  /// Calculate link density (ratio of link text to total text)
+  double _getLinkDensity(Element element) {
+    final text = element.text;
+    if (text.isEmpty) return 0;
+
+    var linkLength = 0;
+    for (final link in element.querySelectorAll('a')) {
+      linkLength += link.text.length;
+    }
+
+    return linkLength / text.length;
+  }
+
+  /// Check if element is unlikely to be content
+  bool _isUnlikelyCandidate(Element element) {
+    final classId = '${element.className} ${element.id}'.toLowerCase();
+
+    for (final pattern in _unlikelyCandidates) {
+      if (classId.contains(pattern)) {
+        // Check if it might still be a candidate
+        for (final ok in _okMaybeItsACandidate) {
+          if (classId.contains(ok)) {
+            return false;
+          }
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Extract page title
+  String _extractTitle(Document document) {
+    // Try Open Graph title first
+    final ogTitle = document.querySelector('meta[property="og:title"]');
+    if (ogTitle != null && ogTitle.attributes['content']?.isNotEmpty == true) {
+      return ogTitle.attributes['content']!.trim();
+    }
+
+    // Try Twitter title
+    final twitterTitle = document.querySelector('meta[name="twitter:title"]');
+    if (twitterTitle != null &&
+        twitterTitle.attributes['content']?.isNotEmpty == true) {
+      return twitterTitle.attributes['content']!.trim();
+    }
+
+    // Try article h1
+    final articleH1 = document.querySelector('article h1');
+    if (articleH1 != null && articleH1.text.trim().isNotEmpty) {
+      return articleH1.text.trim();
+    }
+
+    // Try any h1
+    final h1 = document.querySelector('h1');
+    if (h1 != null && h1.text.trim().isNotEmpty) {
+      return h1.text.trim();
+    }
+
+    // Fall back to title tag
+    final title = document.querySelector('title');
+    if (title != null && title.text.trim().isNotEmpty) {
+      // Clean common suffixes like " | Site Name" or " - Site Name"
+      return title.text.trim().split(RegExp(r'\s*[\|\-–—]\s*')).first.trim();
+    }
+
+    return 'Untitled';
+  }
+
+  /// Extract page description
+  String? _extractDescription(Document document) {
+    // Try Open Graph description
+    final ogDesc = document.querySelector('meta[property="og:description"]');
+    if (ogDesc != null && ogDesc.attributes['content']?.isNotEmpty == true) {
+      return ogDesc.attributes['content'];
+    }
+
+    // Try meta description
+    final metaDesc = document.querySelector('meta[name="description"]');
+    if (metaDesc != null &&
+        metaDesc.attributes['content']?.isNotEmpty == true) {
+      return metaDesc.attributes['content'];
+    }
+
+    return null;
+  }
+
+  /// Extract main image URL
+  String? _extractImage(Document document, String baseUrl) {
+    // Try Open Graph image
+    final ogImage = document.querySelector('meta[property="og:image"]');
+    if (ogImage != null && ogImage.attributes['content']?.isNotEmpty == true) {
+      return _resolveUrl(ogImage.attributes['content']!, baseUrl);
+    }
+
+    // Try Twitter image
+    final twitterImage = document.querySelector('meta[name="twitter:image"]');
+    if (twitterImage != null &&
+        twitterImage.attributes['content']?.isNotEmpty == true) {
+      return _resolveUrl(twitterImage.attributes['content']!, baseUrl);
+    }
+
+    return null;
+  }
+
+  /// Resolve relative URLs to absolute
+  String _resolveUrl(String url, String baseUrl) {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      return url;
+    }
+    if (url.startsWith('//')) {
+      return 'https:$url';
+    }
+    final base = Uri.parse(baseUrl);
+    if (url.startsWith('/')) {
+      return '${base.scheme}://${base.host}$url';
+    }
+    return '${base.scheme}://${base.host}/${base.path}/$url';
+  }
+
+  /// Remove unwanted elements from document
+  void _removeUnwantedElements(Document document) {
+    // Remove script, style, nav, etc.
+    for (final selector in _removeElements) {
+      document.querySelectorAll(selector).forEach((e) => e.remove());
+    }
+
+    // Remove unlikely candidates
+    final body = document.body;
+    if (body != null) {
+      final toRemove = <Element>[];
+      for (final element in body.querySelectorAll('*')) {
+        if (_isUnlikelyCandidate(element)) {
+          toRemove.add(element);
+        }
+      }
+      for (final element in toRemove) {
+        element.remove();
+      }
+    }
+
+    // Remove empty elements
+    document.querySelectorAll('p, div, span').where((e) {
+      return e.text.trim().isEmpty && e.children.isEmpty;
+    }).forEach((e) => e.remove());
+
+    // Remove hidden elements
+    document.querySelectorAll('[hidden], [style*="display:none"], [style*="display: none"]')
+        .forEach((e) => e.remove());
+  }
+
+  /// Extract clean text from an element
+  String _extractTextFromElement(Element element) {
+    final buffer = StringBuffer();
+    
+    // Get all text-containing elements
+    final textElements = element.querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, blockquote, pre');
+
+    if (textElements.isNotEmpty) {
+      for (final el in textElements) {
+        final tagName = el.localName?.toLowerCase() ?? '';
+        var text = el.text.trim();
+        
+        if (text.isEmpty) continue;
+        
+        // Skip if parent is already processed (nested lists)
+        if (el.parent?.localName == 'li') continue;
+        
+        // Add heading markers
+        if (tagName.startsWith('h') && tagName.length == 2) {
+          buffer.writeln();
+          buffer.writeln(text.toUpperCase());
+          buffer.writeln();
+        } else if (tagName == 'blockquote') {
+          buffer.writeln('"$text"');
+          buffer.writeln();
+        } else if (tagName == 'li') {
+          buffer.writeln('• $text');
+        } else {
+          buffer.writeln(text);
+          buffer.writeln();
+        }
+      }
+    } else {
+      // Fall back to all text content
+      buffer.write(element.text);
+    }
+
+    // Clean up the text
+    return buffer
+        .toString()
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n') // Remove excessive newlines
+        .replaceAll(RegExp(r'[ \t]+'), ' ') // Normalize spaces
+        .replaceAll(RegExp(r' +\n'), '\n') // Remove trailing spaces
+        .trim();
+  }
+}
+
+/// Error codes for web extraction
+enum WebExtractorErrorCode {
+  httpError,
+  networkError,
+  timeout,
+  noContent,
+  invalidUrl,
+  unknown,
+}
+
+/// Exception for web extraction errors
+class WebExtractorException implements Exception {
+  final String message;
+  final WebExtractorErrorCode code;
+
+  const WebExtractorException(this.message, {required this.code});
+
+  @override
+  String toString() => message;
+}

--- a/lib/features/tts/presentation/screens/home_screen.dart
+++ b/lib/features/tts/presentation/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:hugeicons_pro/hugeicons.dart';
 
 import '../../../../core/constants/app_constants.dart';
+import '../../../../core/services/web_extractor_service.dart';
 import '../controllers/tts_controller.dart';
 import '../widgets/playback_controls.dart';
 import '../widgets/settings_bottom_sheet.dart';
@@ -18,6 +19,11 @@ class _HomeScreenState extends State<HomeScreen> {
   final TtsController _ttsController = TtsController();
   final TextEditingController _textController = TextEditingController();
   final FocusNode _focusNode = FocusNode();
+  final WebExtractorService _webExtractor = WebExtractorService();
+
+  bool _isExtractingUrl = false;
+  String? _extractedTitle;
+  String? _sourceUrl;
 
   @override
   void initState() {
@@ -69,15 +75,68 @@ class _HomeScreenState extends State<HomeScreen> {
   void _clearText() {
     _textController.clear();
     _ttsController.stop();
+    _extractedTitle = null;
+    _sourceUrl = null;
     setState(() {});
   }
 
   Future<void> _pasteText() async {
     final clipboardData = await Clipboard.getData(Clipboard.kTextPlain);
     if (clipboardData?.text != null && clipboardData!.text!.isNotEmpty) {
-      _textController.text = clipboardData.text!;
-      setState(() {});
+      final text = clipboardData.text!.trim();
+      
+      // Check if it's a URL
+      if (WebExtractorService.isValidUrl(text)) {
+        await _extractFromUrl(text);
+      } else {
+        _textController.text = text;
+        _extractedTitle = null;
+        _sourceUrl = null;
+        setState(() {});
+      }
     }
+  }
+
+  Future<void> _extractFromUrl(String url) async {
+    setState(() {
+      _isExtractingUrl = true;
+      _extractedTitle = null;
+      _sourceUrl = null;
+    });
+
+    try {
+      final content = await _webExtractor.extractFromUrl(url);
+      if (mounted) {
+        _textController.text = content.content;
+        _extractedTitle = content.title;
+        _sourceUrl = content.sourceUrl;
+        setState(() {
+          _isExtractingUrl = false;
+        });
+      }
+    } on WebExtractorException catch (e) {
+      if (mounted) {
+        setState(() {
+          _isExtractingUrl = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(e.message),
+            behavior: SnackBarBehavior.floating,
+            action: SnackBarAction(label: 'OK', onPressed: () {}),
+          ),
+        );
+      }
+    }
+  }
+
+  void _onTextChanged(String value) {
+    // Reset extracted content info if user manually edits
+    if (_sourceUrl != null) {
+      _extractedTitle = null;
+      _sourceUrl = null;
+    }
+    setState(() {});
   }
 
   @override
@@ -119,22 +178,63 @@ class _HomeScreenState extends State<HomeScreen> {
                       ),
                       child: Stack(
                         children: [
-                          TextField(
-                            controller: _textController,
-                            focusNode: _focusNode,
-                            maxLines: null,
-                            expands: true,
-                            textAlignVertical: TextAlignVertical.top,
-                            style: Theme.of(
-                              context,
-                            ).textTheme.bodyLarge?.copyWith(height: 1.6),
-                            decoration: const InputDecoration(
-                              hintText: 'Paste or type your text here...',
+                          // Loading overlay for URL extraction
+                          if (_isExtractingUrl)
+                            Container(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .surface
+                                  .withValues(alpha: 0.8),
+                              child: Center(
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const CircularProgressIndicator(),
+                                    const SizedBox(height: 16),
+                                    Text(
+                                      'Extracting content...',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .bodyMedium
+                                          ?.copyWith(
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .outline,
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            )
+                          else
+                            TextField(
+                              controller: _textController,
+                              focusNode: _focusNode,
+                              maxLines: null,
+                              expands: true,
+                              textAlignVertical: TextAlignVertical.top,
+                              style: Theme.of(
+                                context,
+                              ).textTheme.bodyLarge?.copyWith(height: 1.6),
+                              decoration: InputDecoration(
+                                hintText: 'Paste text or URL here...',
+                                // Show extracted title as label
+                                labelText: _extractedTitle,
+                                labelStyle: Theme.of(context)
+                                    .textTheme
+                                    .titleSmall
+                                    ?.copyWith(
+                                      color:
+                                          Theme.of(context).colorScheme.primary,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                floatingLabelBehavior:
+                                    FloatingLabelBehavior.always,
+                              ),
+                              onChanged: _onTextChanged,
                             ),
-                            onChanged: (_) => setState(() {}),
-                          ),
-                          // Paste button (shown when empty)
-                          if (_textController.text.isEmpty)
+                          // Paste button (shown when empty and not loading)
+                          if (_textController.text.isEmpty && !_isExtractingUrl)
                             Positioned(
                               bottom: 16,
                               right: 16,
@@ -159,6 +259,39 @@ class _HomeScreenState extends State<HomeScreen> {
                       ),
                     ),
                   ),
+
+                  // Source URL indicator (when content extracted from URL)
+                  if (_sourceUrl != null && _textController.text.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 4,
+                      ),
+                      child: Row(
+                        children: [
+                          Icon(
+                            HugeIconsStroke.link01,
+                            size: 14,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                          const SizedBox(width: 6),
+                          Expanded(
+                            child: Text(
+                              _sourceUrl!,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(
+                                    color:
+                                        Theme.of(context).colorScheme.primary,
+                                  ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
 
                   // Clear button & Character count (only show when there's text)
                   if (_textController.text.isNotEmpty)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -200,6 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.3.3"
+  html:
+    dependency: "direct main"
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   http:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   just_audio: ^0.10.5
   audio_session: ^0.2.2
   path_provider: ^2.1.5
+  html: ^0.15.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
Add the ability to extract and read content from web URLs.

## Changes
- Add `WebExtractorService` with Readability-like algorithm for content extraction
- Auto-detect URLs when pasting content
- Score HTML elements to find main article content
- Extract title, description, and clean text
- Show loading indicator during extraction
- Display source URL and extracted title in UI
- Handle errors gracefully with user feedback

## How to Test
1. Copy a URL to an article (e.g., from Medium, news sites)
2. Open the app and tap Paste
3. The app should extract the article content and display it
4. Play the audio to listen to the article

Closes #1